### PR TITLE
Bump idna and urllib3 in kivy/requirements.txt to close Dependabot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,8 @@ Dates in this file are in format of YYYY-MM-DD (2019-12-12 means 12th of Decembe
 * Download folder manager [alastairhm](https://github.com/alastairhm)
 * Clipboard recorder script [alastairhm](https://github.com/alastairhm)
 
+### Security
+
+* Bump idna from 3.7 to 3.19 in /kivy, resolving GHSA-65pc-fj4g-8rjx [alastairhm](https://github.com/alastairhm)
+* Bump urllib3 from 2.6.3 to 2.7.0 in /kivy, resolving GHSA-qccp-gfcp-xxvc and GHSA-mf9v-mfxr-j63j [alastairhm](https://github.com/alastairhm)
+

--- a/kivy/requirements.txt
+++ b/kivy/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 charset-normalizer==2.0.4
 docutils==0.17.1
-idna==3.7
+idna==3.19
 Kivy==2.0.0
 Kivy-examples==2.0.0
 Kivy-Garden==0.1.4
@@ -10,4 +10,4 @@ pygame==2.0.1
 Pygments==2.20.0
 PyYAML==5.4.1
 requests==2.33.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
## Summary
Closes the 3 remaining open Dependabot alerts (all in `kivy/requirements.txt`):

* `idna` 3.7 → 3.19 — fixes [GHSA-65pc-fj4g-8rjx](https://github.com/alastairhm/automate_python/security/dependabot/36) (medium)
* `urllib3` 2.6.3 → 2.7.0 — fixes [GHSA-qccp-gfcp-xxvc](https://github.com/alastairhm/automate_python/security/dependabot/35) (high) and [GHSA-mf9v-mfxr-j63j](https://github.com/alastairhm/automate_python/security/dependabot/34) (high)

All other historical alerts in this repo are already `fixed` (mostly resolved by the recent Pillow 12.3.0 bump).

CHANGELOG.md updated under Unreleased / Security per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)