### PR TITLE
Update README to match current script layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,18 @@ Scripts created from [AUTOMATE THE BORING STUFF WITH PYTHON](https://automatethe
 
 ## Scripts
 
-* calc.py - testing Fire library
-* check_port.py - test if a port is open
-* cidr.py - cidr to IP range
-* clippy.py - Clipboard histroy
-* downloads.py - organise your downloads folder
-* gitremote.py - form HTTPS URL from git SSH link
-* hello.py - Fire CLI test
-* hello2.py - Fire CLI test
-* mapIt.py - search in Google Maps
-* password.py - random password generator
-* searchIt.py - Search from CLI moved to [https://github.com/alastairhm/searchit](https://github.com/alastairhm/searchit)
+* **check_port.py** - checks whether a TCP port on a given address is open
+* **cidr.py** - converts a CIDR range into its first and last IP address
+* **clippy.py** - polls the clipboard and appends new entries to a YAML history file (config in `clippy.toml`)
+* **downloads.py** - sorts files in the current working directory into subfolders by extension, per the mapping in `mapping.yaml`
+* **gitremote.py** - converts a git SSH remote URL into an HTTPS URL and opens it in a browser
+* **mapIt.py** - opens a Google Maps search for an address passed as args or read from the clipboard
+* **password.py** - random password generator (`secrets`, `string`); usable as a CLI or as a `Password` class
 
+`searchIt.py` has moved to its own repo: [https://github.com/alastairhm/searchit](https://github.com/alastairhm/searchit)
+
+## Subdirectories
+
+* **python_fire/** - examples of the [`fire`](https://github.com/google/python-fire) CLI library (`hello.py`, `hello2.py`, `calc.py`)
+* **kivy/** - a minimal [Kivy](https://kivy.org/) app experiment (`test.py`)
+* **archive/** - holding place for retired scripts (currently empty)


### PR DESCRIPTION
## Summary
README's Scripts list had drifted from the repo layout:

* `calc.py`, `hello.py`, `hello2.py` were listed as root scripts, but they live in `python_fire/`
* `searchIt.py` was still listed with a summary even though it's moved out to its own repo
* One-liners were thin/stale (e.g. "Clipboard histroy")

This PR brings the list back in sync with the actual root scripts, expands each into an accurate one-line summary, and adds a Subdirectories section for `python_fire/`, `kivy/`, and `archive/`.

No CHANGELOG.md entry — this is a docs-only correction, no new script (same precedent as the CLAUDE.md-only commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)